### PR TITLE
Release notes for hotwax/fulfillment v3.8.0

### DIFF
--- a/drafts/hotwax/fulfillment/v3.8.0.md
+++ b/drafts/hotwax/fulfillment/v3.8.0.md
@@ -1,0 +1,10 @@
+# hotwax/fulfillment – Release v3.8.0
+
+## What’s New
+
+## Improvements
+
+## Fixes
+- Restrict carrier selection and preserve shipment method for ship-to-store orders
+
+## Technical Notes


### PR DESCRIPTION
Release notes for [hotwax/fulfillment v3.8.0](https://github.com/hotwax/fulfillment/releases/tag/v3.8.0).

Generated by Release Notes Agent.