### PR TITLE
Release notes for hotwax/inventory-count (Jan 2026)

### DIFF
--- a/drafts/hotwax/inventory-count/v4.3.2.md
+++ b/drafts/hotwax/inventory-count/v4.3.2.md
@@ -1,0 +1,10 @@
+# hotwax/inventory-count – Release v4.3.2
+
+## What’s New
+
+## Improvements
+
+## Fixes
+- Fix systemic QOH when marking uncounted items out of stock (#1348)
+
+## Technical Notes

--- a/drafts/hotwax/inventory-count/v4.3.3.md
+++ b/drafts/hotwax/inventory-count/v4.3.3.md
@@ -1,0 +1,10 @@
+# hotwax/inventory-count – Release v4.3.3
+
+## What’s New
+
+## Improvements
+
+## Fixes
+- Handle missing QOH during sync (#1354)
+
+## Technical Notes

--- a/drafts/hotwax/inventory-count/v4.4.0.md
+++ b/drafts/hotwax/inventory-count/v4.4.0.md
@@ -1,0 +1,12 @@
+# hotwax/inventory-count – Release v4.4.0
+
+## What’s New
+
+## Improvements
+
+## Fixes
+- Fix scan removal to be per-scan (#1342)
+- Fix systemic QOH when marking uncounted items out of stock (#1348)
+- Handle missing QOH during sync (#1354)
+
+## Technical Notes

--- a/drafts/hotwax/inventory-count/v4.5.0.md
+++ b/drafts/hotwax/inventory-count/v4.5.0.md
@@ -1,0 +1,11 @@
+# hotwax/inventory-count – Release v4.5.0
+
+## What’s New
+
+## Improvements
+- Add clear local database action (#1356)
+- Add primary/secondary ID support in variance review lists (#1359)
+
+## Fixes
+
+## Technical Notes

--- a/drafts/hotwax/inventory-count/v4.6.0.md
+++ b/drafts/hotwax/inventory-count/v4.6.0.md
@@ -1,0 +1,13 @@
+# hotwax/inventory-count – Release v4.6.0
+
+## What’s New
+- Implemented agent execution model to execute instructions (#1370)
+
+## Improvements
+- Added filter of DISCONTINUED category products (#1368)
+- Added confirmation modal on scanEvent removal (#1365)
+- Added support for live search in match product modal (#1364)
+
+## Fixes
+
+## Technical Notes

--- a/drafts/hotwax/inventory-count/v4.6.1.md
+++ b/drafts/hotwax/inventory-count/v4.6.1.md
@@ -1,0 +1,10 @@
+# hotwax/inventory-count – Release v4.6.1
+
+## What’s New
+
+## Improvements
+
+## Fixes
+- Fixed: Blank rows when negating the scan events (#1372)
+
+## Technical Notes


### PR DESCRIPTION
Release notes for 6 releases of **hotwax/inventory-count** published in January 2026:
- [v4.6.1](https://github.com/hotwax/inventory-count/releases/tag/v4.6.1)
- [v4.6.0](https://github.com/hotwax/inventory-count/releases/tag/v4.6.0)
- [v4.5.0](https://github.com/hotwax/inventory-count/releases/tag/v4.5.0)
- [v4.4.0](https://github.com/hotwax/inventory-count/releases/tag/v4.4.0)
- [v4.3.3](https://github.com/hotwax/inventory-count/releases/tag/v4.3.3)
- [v4.3.2](https://github.com/hotwax/inventory-count/releases/tag/v4.3.2)

Generated by Release Notes Agent.